### PR TITLE
v0.8.0

### DIFF
--- a/DSCR_Firefox.psd1
+++ b/DSCR_Firefox.psd1
@@ -12,25 +12,25 @@
     # RootModule = ''
 
     # このモジュールのバージョン番号です。
-    ModuleVersion     = '0.7.1'
+    ModuleVersion        = '0.8.0'
 
     # サポートされている PSEditions
     # CompatiblePSEditions = @()
 
     # このモジュールを一意に識別するために使用される ID
-    GUID              = '3e3ba330-6cde-4ff2-9324-1f3e4ee4fdd2'
+    GUID                 = '3e3ba330-6cde-4ff2-9324-1f3e4ee4fdd2'
 
     # このモジュールの作成者
-    Author            = 'mkht'
+    Author               = 'mkht'
 
     # このモジュールの会社またはベンダー
     # CompanyName = 'Unknown'
 
     # このモジュールの著作権情報
-    Copyright         = '(c) 2017 mkht. All rights reserved.'
+    Copyright            = '(c) 2018 mkht. All rights reserved.'
 
     # このモジュールの機能の説明
-    Description       = 'DSC Resource to manage Firefox'
+    Description          = 'DSC Resource to manage Firefox'
 
     # このモジュールに必要な Windows PowerShell エンジンの最小バージョン
     # PowerShellVersion = ''
@@ -51,7 +51,7 @@
     # ProcessorArchitecture = ''
 
     # このモジュールをインポートする前にグローバル環境にインポートされている必要があるモジュール
-    RequiredModules   = @( 'DSCR_Application', 'DSCR_IniFile' )
+    RequiredModules      = @( 'DSCR_Application', 'DSCR_IniFile' )
 
     # このモジュールをインポートする前に読み込まれている必要があるアセンブリ
     # RequiredAssemblies = @()
@@ -69,16 +69,16 @@
     # NestedModules = @()
 
     # このモジュールからエクスポートする関数です。最適なパフォーマンスを得るには、ワイルドカードを使用せず、エクスポートする関数がない場合は、エントリを削除しないで空の配列を使用してください。
-    FunctionsToExport = @()
+    FunctionsToExport    = @()
 
     # このモジュールからエクスポートするコマンドレットです。最適なパフォーマンスを得るには、ワイルドカードを使用せず、エクスポートするコマンドレットがない場合は、エントリを削除しないで空の配列を使用してください。
-    CmdletsToExport   = @()
+    CmdletsToExport      = @()
 
     # このモジュールからエクスポートする変数
-    VariablesToExport = '*'
+    VariablesToExport    = '*'
 
     # このモジュールからエクスポートするエイリアスです。最適なパフォーマンスを得るには、ワイルドカードを使用せず、エクスポートするエイリアスがない場合は、エントリを削除しないで空の配列を使用してください。
-    AliasesToExport   = @()
+    AliasesToExport      = @()
 
     # このモジュールからエクスポートする DSC リソース
     DscResourcesToExport = @('cFirefox', 'cFirefoxBookmarks', 'cFirefoxPrefs')
@@ -90,7 +90,7 @@
     # FileList = @()
 
     # RootModule/ModuleToProcess に指定されているモジュールに渡すプライベート データ。これには、PowerShell で使用される追加のモジュール メタデータを含む PSData ハッシュテーブルが含まれる場合もあります。
-    PrivateData       = @{
+    PrivateData          = @{
 
         PSData = @{
 

--- a/DSCResources/cFirefox/cFirefox.schema.psm1
+++ b/DSCResources/cFirefox/cFirefox.schema.psm1
@@ -2,34 +2,61 @@
 {
     param
     (
-        [string]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
+        [string]
         $VersionNumber,
+
+        [Parameter()]
         [string]
         $Language = "en-US",
+
+        [Parameter()]
         [ValidateSet("x86", "x64")]
         [string]
         $MachineBits = "x86",
+
+        [Parameter()]
         [string]
         $InstallerPath,
+
+        [Parameter()]
         [string]
         $LocalPath = "$env:SystemDrive\Windows\temp\DtlDownloads\Firefox Setup " + $VersionNumber + ".exe",
+
+        [Parameter()]
         [string]
         $InstallDirectoryName,
+
+        [Parameter()]
         [string]
         $InstallDirectoryPath,
+
+        [Parameter()]
         [bool]
         $QuickLaunchShortcut = $false,
+
+        [Parameter()]
         [bool]
         $DesktopShortcut = $true,
+
+        [Parameter()]
         [bool]
         $TaskbarShortcut = $false,
+
+        [Parameter()]
         [bool]
         $MaintenanceService = $true,
+
+        [Parameter()]
         [bool]
         $StartMenuShortcuts = $true,
+
+        [Parameter()]
         [string]
         $StartMenuDirectoryName = 'Mozilla Firefox',
+
+        [Parameter()]
         [bool]
         $OptionalExtensions = $true #only Firefox 60+
     )
@@ -39,7 +66,7 @@
     if ($MachineBits -eq "x64") {
         $OS = "win64"
     }
-    else{
+    else {
         $OS = "win32"
     }
 
@@ -54,30 +81,40 @@
         ("StartMenuDirectoryName=" + $StartMenuDirectoryName),
         ("OptionalExtensions=" + $OptionalExtensions.ToString().toLower())
     )
+
     if ($InstallDirectoryName) {
         $IniContent += ("InstallDirectoryName=" + $InstallDirectoryName)
     }
+
     if ($InstallDirectoryPath) {
         $IniContent += ("InstallDirectoryPath=" + $InstallDirectoryPath)
     }
 
-    if(-not $InstallerPath){
+    if (-not $InstallerPath) {
         $InstallerPath = ("https://ftp.mozilla.org/pub/firefox/releases/{0}/{1}/{2}/Firefox%20Setup%20{0}.exe" -f $VersionNumber, $OS, $Language)
     }
 
+    if ($VersionNumber -match 'esr') {
+        $v1 = $VersionNumber.Substring(0, $VersionNumber.IndexOf('esr'))
+        $AppName = ("Mozilla Firefox {0}{1} ({2} {3})" -f $v1, ' ESR', $MachineBits, $Language)
+    }
+    else {
+        $AppName = ("Mozilla Firefox {0} ({1} {2})" -f $VersionNumber, $MachineBits, $Language)
+    }
+
+
     cApplication Install
     {
-        Name      = "Mozilla Firefox " + $VersionNumber + " (" + $MachineBits + " " + $Language + ")"
+        Name          = $AppName
         InstallerPath = $InstallerPath
-        Arguments = "-ms /INI=$IniPath"
-        PreAction = {
+        Arguments     = "-ms /INI=$IniPath"
+        PreAction     = {
             $parent = (split-path -Path $using:IniPath -Parent)
             if (-not (Test-Path -Path $parent)) {
                 New-Item -Path $parent -ItemType Directory -Force | Out-Null
             }
             $using:IniContent -join "`r`n" | Out-File -FilePath $using:IniPath -Encoding ascii -Force
         }
-        NoRestart = $true
+        NoRestart     = $true
     }
-
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 mkht
+Copyright (c) 2018 mkht
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Install Firefox
     + Specify the machine's operating system bit number.
     + The default is `x86`. (`x86` or `x64`)
 
++ [string] **InstallerPath** (Optional):
+    + The path of the the Firefox installer file.
+    + If this value is not specified, The Installer will be downloaded from Mozilla. (https://ftp.mozilla.org/pub/firefox/releases/)
+    + Please use if you want to use self-customized installer or if the target machine is not connected to the Internet.
+
 + [string] **InstallDirectoryName** (Optional):
     + The name of the directory where the Firefox will be installed.
     + If this value is specified then `InstallDirectoryPath` will be ignored.
@@ -54,6 +59,20 @@ Install Firefox
     + Specify whether the MozillaMaintenance service will be installed or not
     + The default is `$true`
 
++ [bool] **StartMenuShortcuts** (Optional):
+    + Create shortcuts for the application in the Start Menu.
+    + The default is `$true`
+
++ [string] **StartMenuDirectoryName** (Optional):
+    + The directory name to use for the StartMenu folder
+    + The default is `Mozilla Firefox`
+
++ [bool] **OptionalExtensions** (Optional):
+    + Set this option to `$false` to opt-out installation of any optional extensions.
+    + The default is `$true`
+    + This option can be used in Firefox 60 or later.
+
+
 ### Examples
 + **Example 1**: Install Firefox 53.0.3 x64 japanese
 ```Powershell
@@ -65,6 +84,19 @@ Configuration Example1
         VersionNumber = "53.0.3"
         Language = "ja"
         Machinebits = "x64"
+    }
+}
+```
+
++ **Example 2**: Install Firefox 60.0 ESR without MozillaMaintenance service
+```Powershell
+Configuration Example1
+{
+    Import-DscResource -ModuleName DSCR_Firefox
+    cFirefox Firefox60ESR
+    {
+        VersionNumber = "60.0esr"
+        MaintenanceService = $false
     }
 }
 ```
@@ -168,6 +200,13 @@ Configuration Example1
 
 ----
 ## ChangeLog
+### 0.8.0
+ + [cFirefox] Now you can specify the ESR version of Firefox. e.g) `VersionNumber = "60.0esr"`
+ + [cFirefox] Add the `OptionalExtensions` param to opt-out installation of any optional extensions. (This option can be used in Firefox 60 or later)
+ + [cFirefox] Add `StartMenuShortcuts` and `StartMenuDirectoryName` params.
+ + [cFirefox] Add the `InstallerPath` param for offline installation.
+ + [cFirefox] Change the download source URL of the installer to `https://ftp.mozilla.org/`
+
 ### 0.7.1
  + Fix issue [#7](https://github.com/mkht/DSCR_Firefox/issues/7) `cFirefoxPrefs` was not loaded some systems.
 


### PR DESCRIPTION
 + [cFirefox] Now you can specify the ESR version of Firefox. e.g) `VersionNumber = "60.0esr"`
 + [cFirefox] Add the `OptionalExtensions` param to opt-out installation of any optional extensions. (This option can be used in Firefox 60 or later)
 + [cFirefox] Add `StartMenuShortcuts` and `StartMenuDirectoryName` params.
 + [cFirefox] Add the `InstallerPath` param for offline installation.
 + [cFirefox] Change the download source URL of the installer to `https://ftp.mozilla.org/`****